### PR TITLE
Build depend on libignition-utils1-cli-dev

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -23,6 +23,7 @@ Build-Depends: cmake,
                libignition-sensors5-dev,
                libignition-rendering5-dev,
                libignition-transport10-log-dev,
+               libignition-utils1-cli-dev,
                libignition-utils1-dev,
                libsdformat11-dev
 Vcs-Browser: https://github.com/ignition-release/ign-gazebo5-release


### PR DESCRIPTION
We aren't using it yet but would like to do so in a minor release. Pairs with https://github.com/ignitionrobotics/ign-gazebo/pull/671